### PR TITLE
Version upgrade (to 0.1.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*vcxproj.filters
+*vcxproj.user

--- a/model/Base.cpp
+++ b/model/Base.cpp
@@ -53,10 +53,9 @@ void Base::init(const vector<vector<string>>&corpus) {
         for (const auto& word : words) {
             df[word]++;
         }
- 
-        // The average length of all documents.
-        avgdl = static_cast<double>(suml) / corpus.size();
     }
+    // The average length of all documents.
+    avgdl = static_cast<double>(suml) / corpus.size();
 }
  
  

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ sfc_module = Extension(
 
 setup(
     name='bm25_search',
-    version='0.1.2',
+    version='0.1.3',
     description='Python Package with BM25 Algorithms C++ extension using Pybind11',
     ext_modules=[sfc_module],
     zip_safe=False,


### PR DESCRIPTION
Version upgrade from 0.1.2 to 01.3.

- Fix a bug related to 'avgdl' in `Base.cpp`.
- Since 'avgdl' was computed inside an extra inner loop, the scores in the previous version were overestimated.